### PR TITLE
Remove option $args from __call

### DIFF
--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -379,7 +379,7 @@ class ShopifyClient
      * @param  array $args
      * @return array|Generator
      */
-    public function __call($method, $args = [])
+    public function __call($method, $args)
     {
         $args = $args[0] ?? [];
 


### PR DESCRIPTION
The __call method's $args parameter is required so adding a default value is unnecessary http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.methods. Removing the default value to avoid compatibility errors as described in https://github.com/mockery/mockery/issues/263.